### PR TITLE
feat: adding click handler that will open template in sheet

### DIFF
--- a/projects/components/src/overlay/overlay.service.ts
+++ b/projects/components/src/overlay/overlay.service.ts
@@ -10,12 +10,12 @@ import { SheetOverlayComponent } from './sheet/sheet-overlay.component';
 
 @Injectable()
 export class OverlayService {
-  public constructor(private readonly popoverService: PopoverService, private readonly injector: Injector) {}
+  public constructor(private readonly popoverService: PopoverService, private readonly defaultInjector: Injector) {}
 
-  public createSheet(config: SheetOverlayConfig): PopoverRef {
+  public createSheet(config: SheetOverlayConfig, injector: Injector = this.defaultInjector): PopoverRef {
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: SheetOverlayComponent,
-      parentInjector: this.injector,
+      parentInjector: injector,
       position: {
         type: PopoverPositionType.Fixed,
         location: PopoverFixedPositionLocation.RightUnderHeader
@@ -26,10 +26,10 @@ export class OverlayService {
     return popover;
   }
 
-  public createModal(config: ModalOverlayConfig): PopoverRef {
+  public createModal(config: ModalOverlayConfig, injector: Injector = this.defaultInjector): PopoverRef {
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: ModalOverlayComponent,
-      parentInjector: this.injector,
+      parentInjector: injector,
       position: {
         type: PopoverPositionType.Fixed,
         location: PopoverFixedPositionLocation.Centered

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/container/detail-sheet-interaction-container.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/container/detail-sheet-interaction-container.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, Inject, InjectionToken } from '@angular/core';
+
+@Component({
+  selector: 'htc-detail-sheet-interaction-container',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-container [hdaDashboardModel]="this.detailModel"></ng-container>`
+})
+export class DetailSheetInteractionContainerComponent {
+  public constructor(@Inject(DETAIL_SHEET_INTERACTION_MODEL) public readonly detailModel: object) {}
+}
+
+export const DETAIL_SHEET_INTERACTION_MODEL = new InjectionToken<unknown>('DETAIL_SHEET_INTERACTION_MODEL');

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/container/detail-sheet-interaction-container.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/container/detail-sheet-interaction-container.component.ts
@@ -9,4 +9,4 @@ export class DetailSheetInteractionContainerComponent {
   public constructor(@Inject(DETAIL_SHEET_INTERACTION_MODEL) public readonly detailModel: object) {}
 }
 
-export const DETAIL_SHEET_INTERACTION_MODEL = new InjectionToken<unknown>('DETAIL_SHEET_INTERACTION_MODEL');
+export const DETAIL_SHEET_INTERACTION_MODEL = new InjectionToken<object>('DETAIL_SHEET_INTERACTION_MODEL');

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
@@ -44,7 +44,7 @@ describe('Detail Sheet Interaction Handler Model', () => {
     const data = 'Test';
     spectator.model.execute(data);
 
-    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson, spectator.model);
+    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson);
     expect(modelApi.setVariable).toHaveBeenCalledWith('source', data, mockModelObject);
     expect(spectator.get(DetailSheetInteractionHandlerService).showSheet).toHaveBeenCalledWith(
       mockModelObject,

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
@@ -77,7 +77,7 @@ describe('Detail Sheet Interaction Handler Model', () => {
     const data = 'Test';
     spectator.model.execute(data);
 
-    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson, spectator.model);
+    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson);
     expect(modelApi.setVariable).toHaveBeenCalledWith('record', data, mockModelObject);
     expect(spectator.get(DetailSheetInteractionHandlerService).showSheet).toHaveBeenCalledWith(
       mockModelObject,

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.test.ts
@@ -1,0 +1,87 @@
+import { SheetSize } from '@hypertrace/components';
+import { createModelFactory } from '@hypertrace/dashboards/testing';
+import { MODEL_API } from '@hypertrace/hyperdash-angular';
+import { mockProvider } from '@ngneat/spectator/jest';
+import { DetailSheetInteractionHandlerModel } from './detail-sheet-interaction-handler.model';
+import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
+
+describe('Detail Sheet Interaction Handler Model', () => {
+  const buildModel = createModelFactory({
+    providers: [
+      mockProvider(DetailSheetInteractionHandlerService, {
+        showSheet: jest.fn()
+      }),
+      {
+        provide: MODEL_API,
+        useValue: {
+          createChild: jest.fn(),
+          setVariable: jest.fn()
+        }
+      }
+    ]
+  });
+
+  test('should work with default values', () => {
+    const modelJson = {
+      type: 'text-widget',
+      // tslint:disable-next-line: no-invalid-template-strings
+      text: '${source}'
+    };
+
+    const mockModelObject = {};
+    const modelApi = {
+      createChild: jest.fn().mockReturnValue(mockModelObject),
+      setVariable: jest.fn()
+    };
+
+    const spectator = buildModel(DetailSheetInteractionHandlerModel, {
+      api: modelApi,
+      properties: {
+        detailTemplate: modelJson
+      }
+    });
+
+    const data = 'Test';
+    spectator.model.execute(data);
+
+    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson, spectator.model);
+    expect(modelApi.setVariable).toHaveBeenCalledWith('source', data, mockModelObject);
+    expect(spectator.get(DetailSheetInteractionHandlerService).showSheet).toHaveBeenCalledWith(
+      mockModelObject,
+      SheetSize.Large
+    );
+  });
+
+  test('should work with custom values', () => {
+    const modelJson = {
+      type: 'text-widget',
+      // tslint:disable-next-line: no-invalid-template-strings
+      text: '${source}'
+    };
+
+    const mockModelObject = {};
+    const modelApi = {
+      createChild: jest.fn().mockReturnValue(mockModelObject),
+      setVariable: jest.fn()
+    };
+
+    const spectator = buildModel(DetailSheetInteractionHandlerModel, {
+      api: modelApi,
+      properties: {
+        detailTemplate: modelJson,
+        injectSourceAs: 'record',
+        sheetSize: SheetSize.Medium
+      }
+    });
+
+    const data = 'Test';
+    spectator.model.execute(data);
+
+    expect(modelApi.createChild).toHaveBeenCalledWith(modelJson, spectator.model);
+    expect(modelApi.setVariable).toHaveBeenCalledWith('record', data, mockModelObject);
+    expect(spectator.get(DetailSheetInteractionHandlerService).showSheet).toHaveBeenCalledWith(
+      mockModelObject,
+      SheetSize.Medium
+    );
+  });
+});

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -1,6 +1,6 @@
 import { SheetSize } from '@hypertrace/components';
 import { EnumPropertyTypeInstance, ENUM_TYPE, ModelTemplatePropertyType } from '@hypertrace/dashboards';
-import { Model, ModelApi, ModelJson, ModelProperty } from '@hypertrace/hyperdash';
+import { Model, ModelApi, ModelJson, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
 import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
 import { Observable, of } from 'rxjs';
 import { InteractionHandler } from '../interaction-handler';
@@ -18,14 +18,20 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
 
   @ModelProperty({
     key: 'sheet-size',
-    required: true,
+    required: false,
     // tslint:disable-next-line: no-object-literal-type-assertion
     type: {
       key: ENUM_TYPE.type,
       values: [SheetSize.Small, SheetSize.Medium, SheetSize.Large]
     } as EnumPropertyTypeInstance
   })
-  public sheetSize!: SheetSize;
+  public sheetSize: SheetSize = SheetSize.Large;
+
+  @ModelProperty({
+    key: 'inject-source-as',
+    type: STRING_PROPERTY.type
+  })
+  public injectSourceAs: string = 'source';
 
   @ModelInject(MODEL_API)
   private readonly api!: ModelApi;
@@ -39,9 +45,9 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
     return of();
   }
 
-  private getDetailModel(record: unknown): object {
+  private getDetailModel(source: unknown): object {
     const detailModel = this.api.createChild<object>(this.detailTemplate, this);
-    this.api.setVariable('record', record, detailModel);
+    this.api.setVariable(this.injectSourceAs, source, detailModel);
 
     return detailModel;
   }

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -1,0 +1,48 @@
+import { SheetSize } from '@hypertrace/components';
+import { EnumPropertyTypeInstance, ENUM_TYPE, ModelTemplatePropertyType } from '@hypertrace/dashboards';
+import { Model, ModelApi, ModelJson, ModelProperty } from '@hypertrace/hyperdash';
+import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
+import { Observable, of } from 'rxjs';
+import { InteractionHandler } from '../interaction-handler';
+import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
+
+@Model({
+  type: 'detail-sheet-interaction-handler'
+})
+export class DetailSheetInteractionHandlerModel implements InteractionHandler {
+  @ModelProperty({
+    key: 'detail-template',
+    type: ModelTemplatePropertyType.TYPE
+  })
+  public detailTemplate!: ModelJson;
+
+  @ModelProperty({
+    key: 'sheet-size',
+    required: true,
+    // tslint:disable-next-line: no-object-literal-type-assertion
+    type: {
+      key: ENUM_TYPE.type,
+      values: [SheetSize.Small, SheetSize.Medium, SheetSize.Large]
+    } as EnumPropertyTypeInstance
+  })
+  public sheetSize!: SheetSize;
+
+  @ModelInject(MODEL_API)
+  private readonly api!: ModelApi;
+
+  @ModelInject(DetailSheetInteractionHandlerService)
+  private readonly handlerService!: DetailSheetInteractionHandlerService;
+
+  public execute(record: unknown): Observable<void> {
+    this.handlerService.showSheet(this.getDetailModel(record), this.sheetSize);
+
+    return of();
+  }
+
+  private getDetailModel(record: unknown): object {
+    const detailModel = this.api.createChild<object>(this.detailTemplate, this);
+    this.api.setVariable('record', record, detailModel);
+
+    return detailModel;
+  }
+}

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -39,8 +39,8 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
   @ModelInject(DetailSheetInteractionHandlerService)
   private readonly handlerService!: DetailSheetInteractionHandlerService;
 
-  public execute(record: unknown): Observable<void> {
-    this.handlerService.showSheet(this.getDetailModel(record), this.sheetSize);
+  public execute(source: unknown): Observable<void> {
+    this.handlerService.showSheet(this.getDetailModel(source), this.sheetSize);
 
     return of();
   }

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -46,7 +46,7 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
   }
 
   private getDetailModel(source: unknown): object {
-    const detailModel = this.api.createChild<object>(this.detailTemplate, this);
+    const detailModel = this.api.createChild<object>(this.detailTemplate);
     this.api.setVariable(this.injectSourceAs, source, detailModel);
 
     return detailModel;

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
@@ -1,6 +1,9 @@
 import { OverlayService, SheetSize } from '@hypertrace/components';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
-import { DetailSheetInteractionContainerComponent } from './container/detail-sheet-interaction-container.component';
+import {
+  DetailSheetInteractionContainerComponent,
+  DETAIL_SHEET_INTERACTION_MODEL
+} from './container/detail-sheet-interaction-container.component';
 import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
 
 describe('Overlay service', () => {
@@ -20,13 +23,21 @@ describe('Overlay service', () => {
   });
 
   test('should call overlay service', () => {
-    spectator.service.showSheet({}, SheetSize.Medium);
+    const detailModel = {};
+    spectator.service.showSheet(detailModel, SheetSize.Medium);
+    const tokenMap = new Map();
+    tokenMap.set(DETAIL_SHEET_INTERACTION_MODEL, detailModel);
+
     expect(spectator.inject(OverlayService).createSheet).toHaveBeenCalledWith(
       {
         content: DetailSheetInteractionContainerComponent,
         size: SheetSize.Medium
       },
-      expect.any(Injector)
+      expect.objectContaining({
+        parent: expect.objectContaining({
+          records: tokenMap
+        })
+      })
     );
   });
 });

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
@@ -26,9 +26,7 @@ describe('Overlay service', () => {
         content: DetailSheetInteractionContainerComponent,
         size: SheetSize.Medium
       },
-      expect.objectContaining({
-        /* Injector */
-      })
+      expect.any(Injector)
     );
   });
 });

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.test.ts
@@ -1,0 +1,34 @@
+import { OverlayService, SheetSize } from '@hypertrace/components';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+import { DetailSheetInteractionContainerComponent } from './container/detail-sheet-interaction-container.component';
+import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
+
+describe('Overlay service', () => {
+  let spectator: SpectatorService<DetailSheetInteractionHandlerService>;
+
+  const createService = createServiceFactory({
+    service: DetailSheetInteractionHandlerService,
+    providers: [
+      mockProvider(OverlayService, {
+        createSheet: jest.fn()
+      })
+    ]
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+  });
+
+  test('should call overlay service', () => {
+    spectator.service.showSheet({}, SheetSize.Medium);
+    expect(spectator.inject(OverlayService).createSheet).toHaveBeenCalledWith(
+      {
+        content: DetailSheetInteractionContainerComponent,
+        size: SheetSize.Medium
+      },
+      expect.objectContaining({
+        /* Injector */
+      })
+    );
+  });
+});

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
@@ -1,0 +1,31 @@
+import { PortalInjector } from '@angular/cdk/portal';
+import { Injectable, Injector } from '@angular/core';
+import { OverlayService, PopoverRef, SheetSize } from '@hypertrace/components';
+import {
+  DetailSheetInteractionContainerComponent,
+  DETAIL_SHEET_INTERACTION_MODEL
+} from './container/detail-sheet-interaction-container.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DetailSheetInteractionHandlerService {
+  public constructor(private readonly injector: Injector, private readonly overlayService: OverlayService) {}
+
+  public showSheet(detailModel: object, sheetSize: SheetSize = SheetSize.Medium): PopoverRef {
+    return this.overlayService.createSheet(
+      {
+        content: DetailSheetInteractionContainerComponent,
+        size: sheetSize
+      },
+      this.buildDetailOverlayInjector(detailModel)
+    );
+  }
+
+  private buildDetailOverlayInjector(detailModel: object): Injector {
+    return new PortalInjector(
+      this.injector,
+      new WeakMap<object, unknown>([[DETAIL_SHEET_INTERACTION_MODEL, detailModel]])
+    );
+  }
+}

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
@@ -1,4 +1,3 @@
-import { PortalInjector } from '@angular/cdk/portal';
 import { Injectable, Injector } from '@angular/core';
 import { OverlayService, PopoverRef, SheetSize } from '@hypertrace/components';
 import {
@@ -6,9 +5,7 @@ import {
   DETAIL_SHEET_INTERACTION_MODEL
 } from './container/detail-sheet-interaction-container.component';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable()
 export class DetailSheetInteractionHandlerService {
   public constructor(private readonly injector: Injector, private readonly overlayService: OverlayService) {}
 
@@ -23,9 +20,14 @@ export class DetailSheetInteractionHandlerService {
   }
 
   private buildDetailOverlayInjector(detailModel: object): Injector {
-    return new PortalInjector(
-      this.injector,
-      new WeakMap<object, unknown>([[DETAIL_SHEET_INTERACTION_MODEL, detailModel]])
-    );
+    return Injector.create({
+      providers: [
+        {
+          provide: DETAIL_SHEET_INTERACTION_MODEL,
+          useValue: detailModel
+        }
+      ],
+      parent: this.injector
+    });
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { DashboardCoreModule } from '@hypertrace/hyperdash-angular';
+import { DetailSheetInteractionContainerComponent } from './container/detail-sheet-interaction-container.component';
+import { DetailSheetInteractionHandlerModel } from './detail-sheet-interaction-handler.model';
+
+@NgModule({
+  imports: [
+    DashboardCoreModule.with({
+      models: [DetailSheetInteractionHandlerModel]
+    })
+  ],
+  declarations: [DetailSheetInteractionContainerComponent]
+})
+export class DetailSheetInteractionModule {}

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { DashboardCoreModule } from '@hypertrace/hyperdash-angular';
 import { DetailSheetInteractionContainerComponent } from './container/detail-sheet-interaction-container.component';
 import { DetailSheetInteractionHandlerModel } from './detail-sheet-interaction-handler.model';
+import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
 
 @NgModule({
   imports: [
@@ -9,6 +10,7 @@ import { DetailSheetInteractionHandlerModel } from './detail-sheet-interaction-h
       models: [DetailSheetInteractionHandlerModel]
     })
   ],
-  declarations: [DetailSheetInteractionContainerComponent]
+  declarations: [DetailSheetInteractionContainerComponent],
+  providers: [DetailSheetInteractionHandlerService]
 })
 export class DetailSheetInteractionModule {}

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/tracing-dashboard-interactions.module.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/tracing-dashboard-interactions.module.ts
@@ -1,11 +1,14 @@
 import { NgModule } from '@angular/core';
 import { DashboardCoreModule } from '@hypertrace/hyperdash-angular';
+import { DetailSheetInteractionModule } from './detail-sheet/detail-sheet-interaction.module';
 import { SpanTraceNavigationHandlerModel } from './span-trace/model/span-trace-navigation-handler.model';
+
 @NgModule({
   imports: [
     DashboardCoreModule.with({
       models: [SpanTraceNavigationHandlerModel]
-    })
+    }),
+    DetailSheetInteractionModule
   ]
 })
 export class TracingDashboardInteractionsModule {}


### PR DESCRIPTION
- We can apply this interaction handler to a table column.
- The row clicked will be available as the variable 'record'. This can be referenced
  in the template itself


Example usage:

```
      {
        type: 'table-widget-column',
        title: 'URL',
        value: {
          type: 'attribute-specification',
          attribute: 'requestUrl'
        },
        'click-handler': {
          type: 'detail-sheet-interaction-handler',
          'sheet-size': SheetSize.Large,
          'detail-template': {
            type: 'trace-detail-widget',
            data: {
              type: 'trace-detail-extended-data-source',
              // tslint:disable-next-line: no-invalid-template-strings
              trace: '${record}'
            }
          }
        }
      },
```