### PR TITLE
feat: add custom color to icons and icons in multi select option

### DIFF
--- a/projects/components/src/icon/icon.component.test.ts
+++ b/projects/components/src/icon/icon.component.test.ts
@@ -26,6 +26,15 @@ describe('Icon component', () => {
     expect(spectator.query('.htc-icon')).toHaveAttribute('aria-label', 'hypertrace');
   });
 
+  test('should apply custom color if provided', () => {
+    const spectator = buildHost(
+      `<htc-icon icon="${IconType.Hypertrace}" color="#FEA395">
+       </htc-icon>`
+    );
+
+    expect(spectator.query('.htc-icon')).toHaveAttribute('style', 'color: rgb(254, 163, 149);');
+  });
+
   test('uses ligatures for icons backed by ligature', () => {
     const spectator = buildHost(
       `<htc-icon icon="${IconType.Add}" label="other label">

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -11,6 +11,7 @@ import { IconSize } from './icon-size';
     <mat-icon
       class="htc-icon"
       [ngClass]="this.size"
+      [ngStyle]="{ color: this.color ? this.color : '' }"
       [attr.aria-label]="this.labelToUse"
       [htcTooltip]="this.showTooltip ? this.labelToUse : undefined"
       [fontSet]="this.fontSet"
@@ -31,6 +32,9 @@ export class IconComponent implements OnChanges {
 
   @Input()
   public showTooltip: boolean = false;
+
+  @Input()
+  public color?: string;
 
   public labelToUse: string = '';
   public fontSet: string = '';

--- a/projects/components/src/multi-select/multi-select.component.scss
+++ b/projects/components/src/multi-select/multi-select.component.scss
@@ -65,8 +65,16 @@
     align-items: center;
     justify-content: space-between;
 
+    .checkbox {
+      margin-right: 8px;
+    }
+
+    .icon {
+      margin-right: 8px;
+    }
+
     .label {
-      padding-right: 8px;
+      margin-right: 8px;
     }
 
     .status-icon {

--- a/projects/components/src/multi-select/multi-select.component.scss
+++ b/projects/components/src/multi-select/multi-select.component.scss
@@ -77,10 +77,6 @@
       margin-right: 8px;
     }
 
-    .status-icon {
-      color: $green-5;
-    }
-
     &:hover {
       background: $gray-1;
     }

--- a/projects/components/src/multi-select/multi-select.component.test.ts
+++ b/projects/components/src/multi-select/multi-select.component.test.ts
@@ -1,4 +1,5 @@
 import { fakeAsync, flush } from '@angular/core/testing';
+import { IconType } from '@hypertrace/assets-library';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { LabelComponent } from '../label/label.component';
@@ -52,11 +53,16 @@ describe('Multi Select Component', () => {
     expect(selectedElements.length).toBe(2);
   }));
 
-  test('should display provided options when clicked', fakeAsync(() => {
+  test('should display provided options with icons when clicked', fakeAsync(() => {
     spectator = hostFactory(
       `
     <htc-multi-select [selected]="selected">
-      <htc-select-option *ngFor="let option of options" [label]="option.label" [value]="option.value">
+      <htc-select-option
+        *ngFor="let option of options"
+        [label]="option.label"
+        [value]="option.value"
+        icon="${IconType.Label}"
+        iconColor="#FEA395">
       </htc-select-option>
     </htc-multi-select>`,
       {
@@ -76,7 +82,10 @@ describe('Multi Select Component', () => {
     const selectedElements = spectator.queryAll('input:checked', { root: true });
     expect(selectedElements.length).toBe(2);
 
-    optionElements.forEach((element, index) => expect(element).toHaveText(selectionOptions[index].label));
+    optionElements.forEach((element, index) => {
+      expect(element).toHaveText(selectionOptions[index].label);
+      expect(element.querySelector('htc-icon')).toExist();
+    });
   }));
 
   test('should notify and update selection when selection is changed', fakeAsync(() => {

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -41,7 +41,14 @@ import { SelectSize } from '../select/select-size';
         <htc-popover-content>
           <div class="multi-select-content">
             <div *ngFor="let item of items" (click)="this.onSelectionChange(item)" class="multi-select-option">
-              <input type="checkbox" [checked]="this.isSelectedItem(item)" />
+              <input class="checkbox" type="checkbox" [checked]="this.isSelectedItem(item)" />
+              <htc-icon
+                class="icon"
+                *ngIf="item.icon"
+                [icon]="item.icon"
+                size="${IconSize.ExtraSmall}"
+                [color]="item.iconColor"
+              ></htc-icon>
               <span class="label">{{ item.label }}</span>
             </div>
           </div>

--- a/projects/components/src/select/select-option.component.ts
+++ b/projects/components/src/select/select-option.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
+import { IconType } from '@hypertrace/assets-library';
 import { Observable, Subject } from 'rxjs';
 import { SelectOption } from './select-option';
 
@@ -16,6 +17,12 @@ export class SelectOptionComponent<V> implements OnChanges, SelectOption<V> {
 
   @Input()
   public style: SelectOptionStyle = SelectOptionStyle.Default;
+
+  @Input()
+  public icon?: IconType;
+
+  @Input()
+  public iconColor?: string;
 
   private readonly optionChangeSubject$: Subject<V> = new Subject<V>();
   public readonly optionChange$: Observable<V> = this.optionChangeSubject$.asObservable();


### PR DESCRIPTION
Add custom color support for icons.
Custom icon and color for options in multi select dropdown.

![Screenshot 2020-08-13 at 4 17 58 PM](https://user-images.githubusercontent.com/63222211/90126093-b7f41300-dd80-11ea-807e-99dfd2689b5e.png)
