### PR TITLE
fix: more changes to support overlay with table

### DIFF
--- a/projects/components/src/overlay/overlay.module.ts
+++ b/projects/components/src/overlay/overlay.module.ts
@@ -1,10 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ModalOverlayModule } from './modal/modal-overlay.module';
-import { OverlayService } from './overlay.service';
 import { SheetOverlayModule } from './sheet/sheet-overlay.module';
 @NgModule({
-  imports: [CommonModule, SheetOverlayModule, ModalOverlayModule],
-  providers: [OverlayService]
+  imports: [CommonModule, SheetOverlayModule, ModalOverlayModule]
 })
 export class OverlayModule {}

--- a/projects/components/src/overlay/overlay.service.ts
+++ b/projects/components/src/overlay/overlay.service.ts
@@ -8,8 +8,12 @@ import { ModalOverlayConfig } from './modal/modal';
 import { ModalOverlayComponent } from './modal/modal-overlay.component';
 import { SheetOverlayComponent } from './sheet/sheet-overlay.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class OverlayService {
+  private activePopover?: PopoverRef;
+
   public constructor(private readonly popoverService: PopoverService, private readonly defaultInjector: Injector) {}
 
   public createSheet(config: SheetOverlayConfig, injector: Injector = this.defaultInjector): PopoverRef {
@@ -23,10 +27,16 @@ export class OverlayService {
       data: config
     });
 
+    popover.closeOnNavigation();
+
+    this.setActivePopover(popover);
+
     return popover;
   }
 
   public createModal(config: ModalOverlayConfig, injector: Injector = this.defaultInjector): PopoverRef {
+    this.activePopover?.close();
+
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: ModalOverlayComponent,
       parentInjector: injector,
@@ -37,6 +47,15 @@ export class OverlayService {
       data: config
     });
 
+    popover.closeOnNavigation();
+
+    this.setActivePopover(popover);
+
     return popover;
+  }
+
+  private setActivePopover(popover: PopoverRef): void {
+    this.activePopover?.close();
+    this.activePopover = popover;
   }
 }

--- a/projects/components/src/overlay/sheet/sheet-overlay.component.scss
+++ b/projects/components/src/overlay/sheet/sheet-overlay.component.scss
@@ -20,11 +20,17 @@
   &.sheet-size-small {
     width: 320px;
   }
+
   &.sheet-size-medium {
     width: 600px;
   }
+
   &.sheet-size-large {
     width: 840px;
+  }
+
+  &.sheet-size-extra-large {
+    width: 1280px;
   }
 
   .header {

--- a/projects/components/src/overlay/sheet/sheet.ts
+++ b/projects/components/src/overlay/sheet/sheet.ts
@@ -7,5 +7,6 @@ export interface SheetOverlayConfig extends OverlayConfig {
 export const enum SheetSize {
   Small = 'small',
   Medium = 'medium',
-  Large = 'large'
+  Large = 'large',
+  ExtraLarge = 'extra-large'
 }

--- a/projects/components/src/table/table.component.test.ts
+++ b/projects/components/src/table/table.component.test.ts
@@ -321,7 +321,7 @@ describe('Table component', () => {
     };
 
     const multiSelectRowColumnConfig = spectator.component.columnConfigsSubject.value[0];
-    const spyToggleRowSelection = spyOn(spectator.component, 'toggleRowSelected');
+    const spyToggleRowSelection = spyOn(spectator.component, 'toggleRowSelectedForMulti');
     spectator.component.onDataCellClick(multiSelectRowColumnConfig, row);
     expect(spyToggleRowSelection).toHaveBeenCalledWith(row);
   });
@@ -354,10 +354,10 @@ describe('Table component', () => {
       }
     };
 
-    spectator.component.toggleRowSelected(row);
+    spectator.component.toggleRowSelectedForMulti(row);
     expect(mockSelectionsChange).toHaveBeenCalledWith([row]);
 
-    spectator.component.toggleRowSelected(row);
+    spectator.component.toggleRowSelectedForMulti(row);
     expect(mockSelectionsChange).toHaveBeenCalledWith([row]);
   });
 

--- a/projects/components/src/table/table.component.test.ts
+++ b/projects/components/src/table/table.component.test.ts
@@ -321,7 +321,7 @@ describe('Table component', () => {
     };
 
     const multiSelectRowColumnConfig = spectator.component.columnConfigsSubject.value[0];
-    const spyToggleRowSelection = spyOn(spectator.component, 'toggleRowSelectedForMulti');
+    const spyToggleRowSelection = spyOn(spectator.component, 'toggleRowSelected');
     spectator.component.onDataCellClick(multiSelectRowColumnConfig, row);
     expect(spyToggleRowSelection).toHaveBeenCalledWith(row);
   });
@@ -354,10 +354,10 @@ describe('Table component', () => {
       }
     };
 
-    spectator.component.toggleRowSelectedForMulti(row);
+    spectator.component.toggleRowSelected(row);
     expect(mockSelectionsChange).toHaveBeenCalledWith([row]);
 
-    spectator.component.toggleRowSelectedForMulti(row);
+    spectator.component.toggleRowSelected(row);
     expect(mockSelectionsChange).toHaveBeenCalledWith([row]);
   });
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -175,7 +175,7 @@ export class TableComponent
     width: '32px',
     visible: true,
     renderer: StandardTableCellRendererType.Checkbox,
-    onClick: (row: StatefulTableRow) => this.toggleRowSelected(row)
+    onClick: (row: StatefulTableRow) => this.toggleRowSelectedForMulti(row)
   };
 
   public readonly expandedDetailColumnConfig: TableColumnConfig = {
@@ -229,6 +229,9 @@ export class TableComponent
 
   @Output()
   public readonly selectionsChange: EventEmitter<StatefulTableRow[]> = new EventEmitter<StatefulTableRow[]>();
+
+  @Output()
+  public readonly rowClicked: EventEmitter<StatefulTableRow> = new EventEmitter<StatefulTableRow>();
 
   @Output()
   public readonly hoveredChange: EventEmitter<StatefulTableRow | undefined> = new EventEmitter<
@@ -345,7 +348,7 @@ export class TableComponent
 
   public onDataRowClick(row: StatefulTableRow): void {
     if (this.hasSelectableRows()) {
-      this.toggleRowSelected(row);
+      this.toggleExistingOrSelectNewRow(row);
     }
   }
 
@@ -421,10 +424,18 @@ export class TableComponent
     this.changeDetector.markForCheck();
   }
 
-  public toggleRowSelected(row: StatefulTableRow): void {
+  public toggleExistingOrSelectNewRow(row: StatefulTableRow): void {
+    const rowIndexInSelections = (this.selections ?? []).findIndex(selection => isEqualIgnoreFunctions(selection, row));
+    rowIndexInSelections >= 0 ? (this.selections = []) : (this.selections = [row]);
+    this.selectionsChange.emit(this.selections);
+    this.changeDetector.markForCheck();
+  }
+
+  public toggleRowSelectedForMulti(row: StatefulTableRow): void {
     const rowSelections = [...(this.selections ?? [])];
     const rowIndexInSelections = rowSelections.findIndex(selection => isEqualIgnoreFunctions(selection, row));
     rowIndexInSelections >= 0 ? rowSelections.splice(rowIndexInSelections, 1) : rowSelections.push(row);
+    this.selections = rowSelections;
     this.selectionsChange.emit(rowSelections);
     this.changeDetector.markForCheck();
   }

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -231,9 +231,6 @@ export class TableComponent
   public readonly selectionsChange: EventEmitter<StatefulTableRow[]> = new EventEmitter<StatefulTableRow[]>();
 
   @Output()
-  public readonly rowClicked: EventEmitter<StatefulTableRow> = new EventEmitter<StatefulTableRow>();
-
-  @Output()
   public readonly hoveredChange: EventEmitter<StatefulTableRow | undefined> = new EventEmitter<
     StatefulTableRow | undefined
   >();

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -46,11 +46,17 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
   @ModelInject(DetailSheetInteractionHandlerService)
   private readonly handlerService!: DetailSheetInteractionHandlerService;
 
-  public execute(source: unknown): Observable<void> {
-    const title = get(source, this.titlePropertyPath ?? '');
-    const model = this.getDetailModel(source);
+  private popover?: PopoverRef;
 
-    this.handlerService.showSheet(model, this.sheetSize, title);
+  public execute(source?: unknown): Observable<void> {
+    if (source) {
+      const title = get(source, this.titlePropertyPath ?? '');
+      const model = this.getDetailModel(source);
+
+      this.popover = this.handlerService.showSheet(model, this.sheetSize, title);
+    } else {
+      this.popover?.close();
+    }
 
     return of();
   }

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.model.ts
@@ -22,7 +22,7 @@ export class DetailSheetInteractionHandlerModel implements InteractionHandler {
     // tslint:disable-next-line: no-object-literal-type-assertion
     type: {
       key: ENUM_TYPE.type,
-      values: [SheetSize.Small, SheetSize.Medium, SheetSize.Large]
+      values: [SheetSize.Small, SheetSize.Medium, SheetSize.Large, SheetSize.ExtraLarge]
     } as EnumPropertyTypeInstance
   })
   public sheetSize: SheetSize = SheetSize.Large;

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction-handler.service.ts
@@ -5,7 +5,9 @@ import {
   DETAIL_SHEET_INTERACTION_MODEL
 } from './container/detail-sheet-interaction-container.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class DetailSheetInteractionHandlerService {
   public constructor(private readonly injector: Injector, private readonly overlayService: OverlayService) {}
 

--- a/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/interaction/detail-sheet/detail-sheet-interaction.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { DashboardCoreModule } from '@hypertrace/hyperdash-angular';
 import { DetailSheetInteractionContainerComponent } from './container/detail-sheet-interaction-container.component';
 import { DetailSheetInteractionHandlerModel } from './detail-sheet-interaction-handler.model';
-import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction-handler.service';
 
 @NgModule({
   imports: [
@@ -10,7 +9,6 @@ import { DetailSheetInteractionHandlerService } from './detail-sheet-interaction
       models: [DetailSheetInteractionHandlerModel]
     })
   ],
-  declarations: [DetailSheetInteractionContainerComponent],
-  providers: [DetailSheetInteractionHandlerService]
+  declarations: [DetailSheetInteractionContainerComponent]
 })
 export class DetailSheetInteractionModule {}

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -31,6 +31,7 @@ import { TableWidgetModel } from './table-widget.model';
         [pageable]="this.api.model.pageable"
         [detailContent]="childDetail"
         [syncWithUrl]="this.syncWithUrl"
+        (selectionsChange)="this.onRowSelection($event)"
       >
       </htc-table>
     </htc-titled-content>
@@ -58,5 +59,9 @@ export class TableWidgetRendererComponent
 
   public get syncWithUrl(): boolean {
     return this.model.style === TableStyle.FullPage;
+  }
+
+  public onRowSelection(selections: TableRow[]): void {
+    this.api.model.selectionHandler?.execute(selections[0]);
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -62,6 +62,6 @@ export class TableWidgetRendererComponent
   }
 
   public onRowSelection(selections: TableRow[]): void {
-    this.api.model.selectionHandler?.execute(selections[0]);
+    this.api.model.selectionHandler?.execute(selections);
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget.model.ts
@@ -19,6 +19,7 @@ import {
 } from '@hypertrace/hyperdash';
 import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
 import { Observable } from 'rxjs';
+import { InteractionHandler } from '../../interaction/interaction-handler';
 import { SpecificationBackedTableColumnDef, TableWidgetColumnModel } from './table-widget-column.model';
 
 @Model({
@@ -79,6 +80,13 @@ export class TableWidgetModel {
     } as EnumPropertyTypeInstance
   })
   public selectionMode: TableSelectionMode = TableSelectionMode.Single;
+
+  @ModelProperty({
+    key: 'selection-handler',
+    displayName: 'Row selection Handler',
+    type: ModelPropertyType.TYPE
+  })
+  public selectionHandler?: InteractionHandler;
 
   @ModelProperty({
     key: 'style',


### PR DESCRIPTION
- Overlay service should be root injectable. It should track the currently active
  sheet/modal popover and ensure that only one sheet/modal instance exist at a
  given time. This helps in avoiding duplicate popover on the screen.
  In general, Only one sheet or modal should be visible at a given time anyway.

- Added a new size to sheet

- Single mode table selection should clear out any previous selection

- Multi selection should store the updated row selection post toggle