### PR TITLE
fix: use fixed position for pagination controls

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -101,7 +101,7 @@
 }
 
 .pagination-controls {
-  position: sticky;
+  position: fixed;
   bottom: 0;
   background: white;
 }

--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -18,6 +18,7 @@
 .table {
   width: 100%;
   overflow: auto;
+  margin-bottom: 50px; // Leave space for pagination controls
 }
 
 .header-row {
@@ -102,6 +103,7 @@
 
 .pagination-controls {
   position: fixed;
+  width: 100%;
   bottom: 0;
   background: white;
 }


### PR DESCRIPTION
Position fixed sticks the pagination control to bottom (including safari).
Width 100% to stretch the controls to full page width.
bottom margin on table to account for the pagination in the bottom.